### PR TITLE
load effective_obfuscation before using it

### DIFF
--- a/lib/effective_orders.rb
+++ b/lib/effective_orders.rb
@@ -1,6 +1,7 @@
 require 'effective_addresses'
 require "effective_orders/engine"
 require 'migrant'     # Required for rspec to run properly
+require 'effective_obfuscation'
 
 module EffectiveOrders
   PURCHASED = 'purchased'


### PR DESCRIPTION
I was not able to get tests running locally but this fix works for my needs.

I believe this could have happened because there are gems in the Gemfile which does not load dependencies in apps that consume this gem.  They are duplicated in the gemspec but the gemspec does not load gems either.  I'm not sure how effective_obfuscation was being loaded previously and why it suddenly broke for me but I do think this is the correct pattern for a gem to follow (requiring it's own dependencies in the `lib/whatever_gem.rb` file).