### PR TITLE
Fix/dependency loading

### DIFF
--- a/app/controllers/effective/providers/stripe.rb
+++ b/app/controllers/effective/providers/stripe.rb
@@ -1,5 +1,3 @@
-require 'stripe'
-
 module Effective
   module Providers
     module Stripe


### PR DESCRIPTION
Removing stripe from the controller module because it causes problems when the file is eager loaded in a project that doesn't use stripe. `stripe` is still required in engine.rb `if config.stripe_enabled == true`.